### PR TITLE
Rename test to reflect it as a simple to string test for pure relation

### DIFF
--- a/test/simple_pure_relation_to_string_test.py
+++ b/test/simple_pure_relation_to_string_test.py
@@ -6,7 +6,6 @@ from ql.legendql import LegendQL
 
 
 class TestPureRelationDialect(unittest.TestCase):
-    """Test cases for column aliasing using walrus operator."""
 
     def setUp(self):
         pass


### PR DESCRIPTION
Rename test to reflect it as a simple to string test for pure relation